### PR TITLE
Fix for NXRM2 testsuite

### DIFF
--- a/src/main/java/org/sonatype/jettytestsuite/ServletServer.java
+++ b/src/main/java/org/sonatype/jettytestsuite/ServletServer.java
@@ -160,7 +160,7 @@ public class ServletServer
 
                         Constraint constraint = new Constraint(
                             webappContext.getAuthenticationInfo().getAuthMethod(),
-                            Constraint.ANY_ROLE );
+                            Constraint.ANY_AUTH );
                         constraint.setAuthenticate( true );
 
                         ConstraintMapping constraintMapping = new ConstraintMapping();


### PR DESCRIPTION
Use ANY_AUTH to allow authentications regardless of authorization configuration.